### PR TITLE
Fix menhaden crash atlnts 93

### DIFF
--- a/currentVersion/at_biology.prm
+++ b/currentVersion/at_biology.prm
@@ -1406,7 +1406,7 @@ flagSDFMigrate 0
 flagFDFMigrate 0
 flagHADMigrate 0
 flagYTFMigrate 0
-flagDOGMigrate 1
+flagDOGMigrate 0
 flagSMOMigrate 0
 flagSSHMigrate 0
 flagDSHMigrate 0
@@ -13023,7 +13023,7 @@ E_BUT 0.35
 E_ANC 0.35
 E_BPF 0.3
 E_GOO 0.3
-E_MEN 0.35
+E_MEN 0.6  # From 0.35
 E_FDE 0.35
 E_COD 0.35
 E_SHK 0.35
@@ -15860,7 +15860,7 @@ recruitRangeFlat 1.5        max relative cohort strength (multiplicative) for gr
 # or number produced per adult (used if recruit flag is set to 12)
  
 KDENR_MAK
-28000000.4
+500000000
 
 KDENR_HER
 50000000000
@@ -15920,7 +15920,7 @@ KDENR_GOO
 432544359.3
 
 KDENR_MEN
-32122718.55
+321227180.55
 
 KDENR_FDE
 2957397.365

--- a/currentVersion/at_harvest.prm
+++ b/currentVersion/at_harvest.prm
@@ -3454,7 +3454,7 @@ CatchTS_agedistribANC      10
 CatchTS_agedistribGOO      10
 0 0 0.05 0.1 0.1 0.1 0.15 0.15 0.15 0.2
 CatchTS_agedistribMEN      10
-0 0 0.05 0.1 0.1 0.1 0.15 0.15 0.15 0.2
+0 0 0 0 0 0.15 0.2 0.3 0.25 0.1
 CatchTS_agedistribFDE      10
 0 0 0.05 0.1 0.1 0.1 0.15 0.15 0.15 0.2
 CatchTS_agedistribCOD      10
@@ -15956,4 +15956,3 @@ netMEN_flag_framebased     0.0
 midwcNSH_flag_framebased   0.0
 midwcOSH_flag_framebased   0.0
 mowMA_flag_framebased      0.0
-

--- a/currentVersion/testingUpdates.Rmd
+++ b/currentVersion/testingUpdates.Rmd
@@ -44,3 +44,11 @@ This file is used to document steps made towards a new version/subversion
     + Herring persisted at full fishing levels - but still drop after the 50th time step, not to as great a magnitude as previously
     + Increased herring recruit numbers
     + Mackerel persist and probably need to have biological parameters reduced a bit to constrain growth
+
+## Mackerel and Menhaden Update
+
+* RG: 05-06-2020
+* Increased Mackerel recruits
+    + Mackerel persists to end now, though at perhaps too high a biomass - will need to be tuned further after next forcing files
+* Increased Menhaden recruits, assimilation efficiency and modified age structure of the catch to allow larger age classes to persist better
+    + Menhaden persists to end now, though at perhaps too high a biomass - will need to be tuned further after next forcing files


### PR DESCRIPTION
## Mackerel and Menhaden Update
* Increased Mackerel recruits
    + Mackerel persists to end now, though at perhaps too high a biomass - will need to be tuned further after next forcing files
* Increased Menhaden recruits, assimilation efficiency and modified age structure of the catch to allow larger age classes to persist better
    + Menhaden persists to end now, though at perhaps too high a biomass - will need to be tuned further after next forcing files