### PR TITLE
Atlnts 277 check whether v6536 fixes migration

### DIFF
--- a/currentVersion/at_biology.prm
+++ b/currentVersion/at_biology.prm
@@ -5364,13 +5364,13 @@ jFLA_Migrate_Time 1
 0
  
 jBFT_Migrate_Time 1
-1
+260
  
 jTUN_Migrate_Time 1
-1
+260
  
 jBIL_Migrate_Time 1
-1
+260
  
 jMPF_Migrate_Time 1
 0
@@ -5463,13 +5463,13 @@ jDSH_Migrate_Time 1
 0
  
 jBLS_Migrate_Time 1
-1
+270
  
 jPOR_Migrate_Time 1
-1
+270
  
 jPSH_Migrate_Time 1
-1
+270
  
 jWSK_Migrate_Time 1
 0
@@ -5481,25 +5481,25 @@ jSK_Migrate_Time 1
 0
  
 jSB_Migrate_Time 1
-1
+224
  
 jPIN_Migrate_Time 1
 0
  
 jREP_Migrate_Time 1
-1
+270
  
 jRWH_Migrate_Time 1
-1
+300
  
 jBWH_Migrate_Time 1
-1
+300
  
 jSWH_Migrate_Time 1
-1
+330
  
 jTWH_Migrate_Time 1
-1
+330
  
 jINV_Migrate_Time 1
 0
@@ -5555,13 +5555,13 @@ FLA_Migrate_Time 1
 0
  
 BFT_Migrate_Time 1
-1
+260
  
 TUN_Migrate_Time 1
-1
+260
  
 BIL_Migrate_Time 1
-1
+260
  
 MPF_Migrate_Time 1
 0
@@ -5654,13 +5654,13 @@ DSH_Migrate_Time 1
 0
  
 BLS_Migrate_Time 1
-1
+270
  
 POR_Migrate_Time 1
-1
+270
  
 PSH_Migrate_Time 1
-1
+270
  
 WSK_Migrate_Time 1
 0
@@ -5672,25 +5672,25 @@ SK_Migrate_Time 1
 0
  
 SB_Migrate_Time 1
-1
+224
  
 PIN_Migrate_Time 1
 0
  
 REP_Migrate_Time 1
-1
+270
  
 RWH_Migrate_Time 1
-1
+300
  
 BWH_Migrate_Time 1
-1
+300
  
 SWH_Migrate_Time 1
-1
+330
  
 TWH_Migrate_Time 1
-1
+330
  
 INV_Migrate_Time 1
 0
@@ -5753,13 +5753,13 @@ jFLA_Migrate_Return 1
 364
  
 jBFT_Migrate_Return 1
-195
+90
  
 jTUN_Migrate_Return 1
-195
+90
  
 jBIL_Migrate_Return 1
-195
+90
  
 jMPF_Migrate_Return 1
 364
@@ -5852,13 +5852,13 @@ jDSH_Migrate_Return 1
 364
  
 jBLS_Migrate_Return 1
-245
+150
  
 jPOR_Migrate_Return 1
-245
+150
  
 jPSH_Migrate_Return 1
-245
+150
  
 jWSK_Migrate_Return 1
 364
@@ -5870,25 +5870,25 @@ jSK_Migrate_Return 1
 364
  
 jSB_Migrate_Return 1
-261
+120
  
 jPIN_Migrate_Return 1
 364
  
 jREP_Migrate_Return 1
-275
+180
  
 jRWH_Migrate_Return 1
-165
+100
  
 jBWH_Migrate_Return 1
-165
+100
  
 jSWH_Migrate_Return 1
-125
+90
  
 jTWH_Migrate_Return 1
-125
+90
  
 jINV_Migrate_Return 1
 364
@@ -5945,13 +5945,13 @@ FLA_Migrate_Return 1
 364
  
 BFT_Migrate_Return 1
-195
+90
  
 TUN_Migrate_Return 1
-195
+90
  
 BIL_Migrate_Return 1
-195
+90
  
 MPF_Migrate_Return 1
 364
@@ -6044,13 +6044,13 @@ DSH_Migrate_Return 1
 364
  
 BLS_Migrate_Return 1
-245
+150
  
 POR_Migrate_Return 1
-245
+150
  
 PSH_Migrate_Return 1
-245
+150
  
 WSK_Migrate_Return 1
 364
@@ -6062,25 +6062,25 @@ SK_Migrate_Return 1
 364
  
 SB_Migrate_Return 1
-261
+120
  
 PIN_Migrate_Return 1
 364
  
 REP_Migrate_Return 1
-275
+180
  
 RWH_Migrate_Return 1
-165
+100
  
 BWH_Migrate_Return 1
-165
+100
  
 SWH_Migrate_Return 1
-125
+90
  
 TWH_Migrate_Return 1
-125
+90
  
 INV_Migrate_Return 1
 364

--- a/currentVersion/testingUpdates.Rmd
+++ b/currentVersion/testingUpdates.Rmd
@@ -135,3 +135,7 @@ This file is used to document steps made towards a new version/subversion
 
     * Changed pprey values on SCA, BFF, and LOB by their 'main' fish predators and decreased clearance rates for the benthic predators.  All benthic groups now persist.
     * Increased growth rates and recruits for the benthic charismatics that were too low.  All are now in reasonable ranges compared to original biomasses, with most doubling to tripling biomass in the absence of human interactions.
+
+## Check whether v6536 fixes migration issues (ATLNTS-277)
+
+    * v6536 fixes the issues we were having with migration out of the model domain near the end of one year and returning in the next.  All migration parameters were reset to the original values.


### PR DESCRIPTION
v6536 fixes the issues we were having with migration out of the model domain near the end of one year and returning in the next.  All migration parameters were reset to the original values.

@andybeet , @jcaracappa1 