### PR TITLE
Atlnts 289 mortality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Imports: 
     angstroms,
+    atlantistools,
     abind,
     bgmfiles,
     data.table,
@@ -48,4 +49,4 @@ Imports:
     visNetwork,
     zoo
 Remotes:
-    alketh/atlantistools
+    andybeet/atlantistools

--- a/R/get_atl_paramfiles.R
+++ b/R/get_atl_paramfiles.R
@@ -22,6 +22,8 @@ get_atl_paramfiles = function(param.dir,atl.dir,include_catch){
   dietcheck = paste0(atl.dir,run.prefix,'DietCheck.txt')
   yoy = paste0(atl.dir,run.prefix,'YOY.txt')
   ssb = paste0(atl.dir,run.prefix,'SSB.txt')
+  mort <- paste0(atl.dir,run.prefix,'Mort.txt')
+  specificmort <- paste0(atl.dir,run.prefix,'SpecificMort.txt')
   
   #If catch is turned on all generate paths for CATCH and TOTCATCH
   if(include_catch){
@@ -79,7 +81,9 @@ get_atl_paramfiles = function(param.dir,atl.dir,include_catch){
                     yoy =yoy,
                     ssb = ssb,
                     catch = ifelse(include_catch,catch,NA),
-                    catchtot = ifelse(include_catch,catchtot,NA)
+                    catchtot = ifelse(include_catch,catchtot,NA),
+                    mort = mort,
+                    specificmort = specificmort
                     )
   
   return(param.list)

--- a/R/make_atlantis_diagnostic_figures.R
+++ b/R/make_atlantis_diagnostic_figures.R
@@ -296,7 +296,7 @@ make_atlantis_diagnostic_figures = function(
     
     
     
-    pdf(paste0(fig.dir,run.name,' Specific Mortality Timeseries2.pdf'),width = 20, height = 20, onefile = T)
+    pdf(paste0(fig.dir,run.name,' Specific Mortality Timeseries.pdf'),width = 20, height = 20, onefile = T)
     for (iplot in 1:(itype+iage+i2age+1)) {
       gridExtra::grid.arrange(plotMort[[iplot]])
     }

--- a/R/process_atl_output.R
+++ b/R/process_atl_output.R
@@ -589,6 +589,6 @@ process_atl_output = function(param.dir,
   #   dplyr::mutate(atoutput = ifelse(is.infinite(atoutput),NA,atoutput))
   saveRDS(mortality,paste0(out.dir,'mort.RDS'))
   
-  specificMortality <- atlantistools::load_spec_mort(param.ls$specificmort,prm_run=param.ls$run.prm,fgs=param.ls$groups.file,convert_names = T)
+  specificMortality <- atlantistools::load_spec_mort(param.ls$specificmort,prm_run=param.ls$run.prm,fgs=param.ls$groups.file,convert_names = T,removeZeros = F)
   saveRDS(specificMortality,paste0(out.dir,'specificmort.RDS'))
 }

--- a/R/process_atl_output.R
+++ b/R/process_atl_output.R
@@ -26,7 +26,7 @@ process_atl_output = function(param.dir,
   
   # memory.limit(size = 56000)
   source(here::here('R','load_nc_temp.R'))
-  
+
   #Utility function
   bind.save = function(x,name){
     x2 = dplyr::bind_rows(x)
@@ -581,4 +581,14 @@ process_atl_output = function(param.dir,
     
     rm(catch,totcatch,catchmt)
   }
+  
+  # Do mortality -------------------------------------------------------------------
+   mortality <- atlantistools::load_mort(param.ls$mort,prm_run=param.ls$run.prm,fgs=param.ls$groups.file,convert_names = T) #%>%
+  #   dplyr::group_by(species,time) %>% 
+  #   dplyr::summarise(atoutput = atoutput[source == "F"]/atoutput[source == "M"],.groups="drop") %>% 
+  #   dplyr::mutate(atoutput = ifelse(is.infinite(atoutput),NA,atoutput))
+  saveRDS(mortality,paste0(out.dir,'mort.RDS'))
+  
+  specificMortality <- atlantistools::load_spec_mort(param.ls$specificmort,prm_run=param.ls$run.prm,fgs=param.ls$groups.file,convert_names = T)
+  saveRDS(specificMortality,paste0(out.dir,'specificmort.RDS'))
 }


### PR DESCRIPTION
## Mortality 

* Updated the three core processing R scripts to accommodate mortality output and plotting
   * get_atl_paramfiles (added paths to mort.txt, and specificMort.txt)
   * process_atl_output (read in and save as RDS files)
   * make_atlantis_diagnostic_figures (plot variety of figures)

## Atlantis tools

For these new plots to function correctly `atlantistools` was forked and modified. You will now need to install `atlantistools` from https://github.com/andybeet/atlantistools to take advantage of new functions
 * added `load_mort`
 * created `load_spec_mort`
 * changed previous `load_spec_mort` to `load_spec_pred_mort`
 * added `get_cohorts`
 * modified `plot_line` to take ylim argument
 * modified `processed_txt` to take removeZeros argument

These changes will be documented in the package update