### PR TITLE
Spawn testing

### DIFF
--- a/R/call_run_comparisons.R
+++ b/R/call_run_comparisons.R
@@ -16,32 +16,22 @@ obs.dir = 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/'
 
 roms.cobalt = paste0(roms.dir,'Atlantis_Runs/Atlantis_Output_Base_06232020/')
 
-new.obs = paste0(obs.dir,'Atlantis_Runs/Obs_Hindcast_NewForcing/')
-master = paste0(obs.dir,'Atlantis_Runs/Master_05242021/')
-master2 = paste0(obs.dir,'Atlantis_Runs/NewHerInit/')
-master3 = paste0(obs.dir,'Atlantis_Runs/Master_06032021/')
-persist1 = paste0(obs.dir,'Atlantis_Runs/PersistCheck_1/')
-persist2 = paste0(obs.dir,'Atlantis_Runs/PersistCheck_2/')
-persist3 = paste0(obs.dir,'Atlantis_Runs/PersistCheck_3/')
-Master_NewPhyto = paste0(obs.dir,'Atlantis_Runs/FixPhytoConversion_17/')
-zoo6 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_6/')
-zoo7 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_7/')
-zoo8 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_8/')
-zoo9 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_9/')
-zoo10 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_10/')
-zoo11 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_11/')
-zoo12 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_12/')
-zoo13 = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_13/')
-zoo13b = paste0(obs.dir,'Atlantis_Runs/ZooRebalance_13b/')
+# new.obs = paste0(obs.dir,'Atlantis_Runs/Obs_Hindcast_NewForcing/')
+master = paste0(obs.dir,'Atlantis_Runs/Master_12172021/')
+phase1 = paste0(obs.dir,'Atlantis_Runs/Phase_1_5day/')
+# rg.test = paste0(obs.dir,'Atlantis_Runs/Output_Rob_noFishing_10_8_21/')
+HAD.BH = paste0(obs.dir,'Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC_UpFSP/')
+all.bh = paste0(obs.dir,'Atlantis_Runs/BH_NEUSv1/')
+all.bh2 = paste0(obs.dir,'Atlantis_Runs/BH_NEUSv1_2/')
 
 figure.dir = paste0(obs.dir,'Diagnostic_Figures/Run_Comparisons/')
 
 plot_run_comparisons(
-  model.dirs = c(zoo11,zoo12,zoo13,zoo13b),
-  model.names = c(paste0('zoo',11:13),'zoo13b'),
+  model.dirs = c(phase1,all.bh2),
+  model.names = c('Phase_1','All-Bev-Holt-2'),
   plot.raw = T,
   plot.diff = F,
-  plot.out = paste(figure.dir,'ZooRebalance_multi_'),
+  plot.out = paste(figure.dir,'All_BH_Test'),
   table.out = F,
   groups = NULL,
   remove.init = F

--- a/R/check_spawn_calculation.R
+++ b/R/check_spawn_calculation.R
@@ -1,10 +1,11 @@
 #Read in spawning data from log.txt
 library(dplyr)
+library(ggplot2)
 source(here::here('R','parse_spawn_log.R'))
 
 spawn1 = parse_spawn_log(file = 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/Master_Test_1day/log.txt',spp = 'HAD')
 spawn2 = parse_spawn_log(file = 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_1day/log.txt',spp = 'HAD')
-spawn3 = parse_spawn_log(file = 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_1day_2/log.txt',spp = 'HAD')
+spawn3 = parse_spawn_log(file = 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC_UpFSP/log.txt',spp = 'HAD')
 
 #Get Age biomass data
 
@@ -17,26 +18,88 @@ age.dat2 = read.table('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast
   select(Time, starts_with('HAD'))
 age.dat2$total = rowSums(age.dat2[,3:11])
 
-age.dat3 = read.table('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_1day_2/neus_outputAgeBiomIndx.txt', header = T) %>%
+age.dat3 = read.table('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X/neus_outputAgeBiomIndx.txt', header = T) %>%
   select(Time, starts_with('HAD'))
-age.dat2$total = rowSums(age.dat2[,3:11])
+# age.dat2$total = rowSums(age.dat2[,3:11])
 
+plot(HAD.0~Time,age.dat3,'l')
 ##Comparison plot between Age 0 and Total Biomass
 plot_spawn_pop = function(file,spp){
   age.dat = read.table(file, header = T) %>%
     select(Time, starts_with(spp))
   age.dat$total = rowSums(age.dat[,3:11])
   
-  plot(total~Time,age.dat,'l', ylim = c(0,4E6))
+  plot(total~Time,age.dat,'l', ylim = c(0,max(c(age.dat$total,age.dat$HAD.0))),xlim = c(0,400))
   lines(HAD.0~Time,age.dat,col = 2)  
 }
 
-par(mfrow= c(3,1))
+age.dat3.long = reshape2::melt(age.dat3,id.var = 'Time')
+
+ggplot(age.dat3.long,aes(x=Time,y=value,fill = variable))+
+  geom_bar(position = 'fill',stat = 'identity')+
+  coord_flip()
+
+par(mfrow= c(4,1))
 
 plot_spawn_pop('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/Master_Test_1day/neus_outputAgeBiomIndx.txt','HAD')
 plot_spawn_pop('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_1day/neus_outputAgeBiomIndx.txt','HAD')
-plot_spawn_pop('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_1day_2/neus_outputAgeBiomIndx.txt','HAD')
+# plot_spawn_pop('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_UpFSP/neus_outputAgeBiomIndx.txt','HAD')
+plot_spawn_pop('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_NoMQ/neus_outputAgeBiomIndx.txt','HAD')
+plot_spawn_pop('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC_UpFSP/neus_outputAgeBiomIndx.txt','HAD')
 
+
+plot_spawn_comp = function(files,spp){
+  
+  dat.ls = list()
+  for(i in 1:length(files)){
+    age.dat = read.table(files[i], header = T) %>%
+      select(Time, starts_with(spp))
+    age.dat$total = rowSums(age.dat[,3:11])
+    age.dat$ratio = age.dat$HAD.0/age.dat$total
+    
+    dat.ls[[i]] = select(age.dat,Time,ratio)%>%mutate(file = i)
+  }
+
+  df = bind_rows(dat.ls)
+  
+  ggplot(data = df,aes(x=Time,y=ratio,color = as.factor(file)))+geom_line()+xlim(0,400)
+}
+
+plot_spawn_comp(files = c('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_NoMQ/neus_outputAgeBiomIndx.txt',
+                          # 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH/neus_outputAgeBiomIndx.txt',
+                          'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X/neus_outputAgeBiomIndx.txt',
+                          'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC/neus_outputAgeBiomIndx.txt',
+                          'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC_UpFSP/neus_outputAgeBiomIndx.txt'
+                          ),
+                spp = 'HAD')
+
+plot_spawn_comp2 = function(files,spp){
+  
+  dat.ls = list()
+  for(i in 1:length(files)){
+    age.dat = read.table(files[i], header = T) %>%
+      select(Time, starts_with(spp))%>%
+      reshape2::melt(id.vars = 'Time')%>%
+      mutate(file = i)
+    dat.ls[[i]] =age.dat
+  }
+  
+  df = bind_rows(dat.ls)%>%
+    filter(variable %in% c('HAD.0','HAD.1'))
+  
+  ggplot(data = df,aes(x=Time,y=value,color = as.factor(file)))+
+    geom_line()+
+    # xlim(0,100)+
+    facet_wrap(~variable,nrow = 2,scales = 'free_y')
+}
+
+plot_spawn_comp2(files = c('C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_NoMQ/neus_outputAgeBiomIndx.txt',
+                          # 'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH/neus_outputAgeBiomIndx.txt',
+                          'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X/neus_outputAgeBiomIndx.txt',
+                          'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC/neus_outputAgeBiomIndx.txt',
+                          'C:/Users/joseph.caracappa/Documents/Atlantis/Obs_Hindcast/Atlantis_Runs/HAD_Test_BH_Up10X_UpMumC_UpFSP/neus_outputAgeBiomIndx.txt'
+),
+spp = 'HAD')
 
 #Check Total Spawn calculation
 spawn.summ = spawn2 %>%
@@ -54,10 +117,24 @@ spawn.summ = spawn2 %>%
   filter(TotSpawn>0)
   # select(Box,Layer,Cohort,TotSpawn,sp,spawn.ratio)
   
-x =spawn.summ  %>%
-  group_by(Box,Layer)%>%
-  mutate(cs = cumsum(recalc.TotSpawn))%>%
-  select(Box:TotSpawn,cs,recalc.TotSpawn)
+# x = spawn2 %>%
+#   group_by(Box,Layer)%>%
+#   summarise(max.spawn = max(TotSpawn))%>%
+#   mutate(recruits = max.spawn/114)
+# 
+# sum(x$recruits)
+# 
+# x =spawn.summ  %>%
+#   group_by(Box,Layer)%>%
+#   mutate(cs = cumsum(recalc.TotSpawn))%>%
+#   select(Box:TotSpawn,cs,recalc.TotSpawn)
+# 
+# 
+# mean(spawn2$spawn.ratio)
 
-
-mean(spawn2$spawn.ratio)
+xx = spawn3 %>% 
+  mutate(w = SN+RN,
+         w0 = 3.65*SN,
+         test = (w/w0)*((1/(FSPB*DEN))-1)+(KSPA/w0)+1)%>%
+  filter(IndSpawn>0)
+mean(xx$test)

--- a/R/edit_param_BH.R
+++ b/R/edit_param_BH.R
@@ -1,0 +1,36 @@
+#Function to edit Beverto-Holt Alpha and Beta parameters in biology.prm
+#group.names, alpha, and beta are vectorized
+
+edit_param_BH = function(bio.prm,group.name,alpha,beta,overwrite = F, new.file.name){
+  
+  bio.lines = readLines(bio.prm)
+  for( i in 1:length(group.name)){
+    
+    alpha.line = grep(paste0('BHalpha_',group.name[i]),bio.lines)
+    beta.line = grep(paste0('BHbeta_',group.name[i]),bio.lines)
+    
+    new.alpha = paste0('BHalpha_',group.name[i],' ',alpha[i])
+    new.beta = paste0('BHbeta_',group.name[i],' ',beta[i])
+    
+    bio.lines[alpha.line] = new.alpha
+    bio.lines[beta.line] = new.beta
+  }
+  
+  if(overwrite){
+    writeLines(bio.lines, con = bio.prm)
+  }else{
+    file.copy(bio.prm, new.file.name, overwrite = T)
+    writeLines(bio.lines, con = new.file.name )
+  }
+  
+  
+}
+
+#Example
+
+# edit_param_BH(bio.prm = here::here('currentVersion','at_biology.prm'),
+#               group.name = c('MAK','HER'),
+#               alpha = c(3.7E9,3E10),
+#               beta = c(7.56E13,3E10),
+#               overwrite = F,
+#               new.file.name = here::here('currentVersion','at_biology_test.prm'))

--- a/R/model_BH.R
+++ b/R/model_BH.R
@@ -1,0 +1,161 @@
+#model Atlantis' Beverton-Holt recruitment with fake numbers
+#somewhat modelled off of HAD
+
+#Fixed Parameters
+XRS = 1.65
+FSP = 0.5
+KSPA = 10
+FSPB = 1
+bh.a = 1E4
+bh.b = 5E3
+
+#Individual Variables
+SN = 100
+RN = SN * XRS
+N = 1
+
+atlantis_BH = function(XRS=1.65,FSP,FSPB,KSPA,bh.a,bh.b,SN,RN,N){
+  
+  #optimal spawning weight
+  w0 = (1+XRS)*SN
+  #total weight
+  w = (SN+RN)
+  
+  #Calculate spawning biomass
+  Sp = ( ((w0*FSP)-KSPA)-(w0-w) )*FSPB*N
+  
+  #Calculate Recruitment
+  Rt = Sp*bh.a/(w + bh.b)
+  
+  return(Rt)
+} 
+
+#Baseline
+atlantis_BH(XRS = XRS,
+            FSP = FSP,
+            FSPB = FSPB,
+            KSPA = KSPA,
+            bh.a = bh.a,
+            bh.b = bh.b,
+            SN = SN,
+            RN = RN, 
+            N =N)
+
+#vary alpha
+bh.a.v = seq(0,1E4,2E3)
+change.bh.a = sapply(bh.a.v,function(x) return(atlantis_BH(XRS = XRS,
+                                                           FSP = FSP,
+                                                           FSPB = FSPB,
+                                                           KSPA = KSPA,
+                                                           bh.a = x,
+                                                           bh.b = bh.b,
+                                                           SN = SN,
+                                                           RN = RN, 
+                                                           N =N)))
+plot(bh.a.v,change.bh.a,type='l')
+
+#vary beta
+bh.b.v = seq(0,1E4,500)
+change.bh.b = sapply(bh.b.v,function(x) return(atlantis_BH(XRS = XRS,
+                                                           FSP = FSP,
+                                                           FSPB = FSPB,
+                                                           KSPA = KSPA,
+                                                           bh.a = bh.a,
+                                                           bh.b = x,
+                                                           SN = SN,
+                                                           RN = RN, 
+                                                           N =N)))
+plot(bh.b.v,change.bh.b,type='l')
+
+#vary FSP
+fsp.v = seq(0,0.5,0.01)
+change.fsp = sapply(fsp.v,function(x) return(atlantis_BH(XRS = XRS,
+                                                           FSP = x,
+                                                           FSPB = FSPB,
+                                                           KSPA = KSPA,
+                                                           bh.a = bh.a,
+                                                           bh.b = bh.b,
+                                                           SN = SN,
+                                                           RN = RN, 
+                                                           N =N)))
+plot(fsp.v,change.fsp,type='l')
+
+#vary FSPB
+fspb.v = seq(0,1,0.05)
+
+change.fspb = sapply(fspb.v,function(x) return(atlantis_BH(XRS = XRS,
+                                                          FSP = FSP,
+                                                          FSPB = x,
+                                                          KSPA = KSPA,
+                                                          bh.a = bh.a,
+                                                          bh.b = bh.b,
+                                                          SN = SN,
+                                                          RN = RN, 
+                                                          N =N)))
+plot(fspb.v,change.fspb,type='l')
+
+#vary KSPA
+kspa.v = seq(0,100,1)
+
+change.kspa = sapply(kspa.v,function(x) return(atlantis_BH(XRS = XRS,
+                                                           FSP = FSP,
+                                                           FSPB = FSPB,
+                                                           KSPA = x,
+                                                           bh.a = bh.a,
+                                                           bh.b = bh.b,
+                                                           SN = SN,
+                                                           RN = RN, 
+                                                           N =N)))
+plot(kspa.v,change.kspa,type='l')
+
+#Vary conditions (RN:SN)
+rn.sn.v = seq(0,1.65,0.05)
+rn.v = rn.sn.v*SN
+
+change.rn = sapply(rn.v,function(x) return(atlantis_BH(XRS = XRS,
+                                                           FSP = FSP,
+                                                           FSPB = FSPB,
+                                                           KSPA = KSPA,
+                                                           bh.a = bh.a,
+                                                           bh.b = bh.b,
+                                                           SN = SN,
+                                                           RN = x, 
+                                                           N =N)))
+plot(rn.sn.v,change.rn,type='l')
+rn.sn.v[which(change.rn>0)[1]]
+
+#Vary alpha & beta
+
+##Fixed alpha
+a.b.v = seq(0,10,0.5)
+bh.a.v = bh.a*a.b.v
+bh.b.v = bh.b*a.b.v
+change.a.b = sapply(1:length(a.b.v),function(x) return(atlantis_BH(XRS = XRS,
+                                                           FSP = FSP,
+                                                           FSPB = FSPB,
+                                                           KSPA = KSPA,
+                                                           bh.a = bh.a.v[x],
+                                                           bh.b = bh.b.v[x],
+                                                           SN = SN,
+                                                           RN = RN, 
+                                                           N =N)))
+plot(a.b.v,change.a.b,type='l')
+
+#Contours of alpha beta combos
+bh.a.seq = seq(0,1E4,100)
+bh.b.seq = seq(0,10100,100)
+
+combs = expand.grid(bh.a.seq,bh.b.seq)
+change.a.b =  sapply(1:nrow(combs),function(x) return(atlantis_BH(XRS = XRS,
+                                                                    FSP = FSP,
+                                                                    FSPB = FSPB,
+                                                                    KSPA = KSPA,
+                                                                    bh.a = combs[x,1],
+                                                                    bh.b = combs[x,2],
+                                                                    SN = SN,
+                                                                    RN = RN, 
+                                                                    N =N)))
+
+change.a.b.mat = matrix(change.a.b,nrow = length(bh.b.seq), ncol = length(bh.a.seq),byrow = T)
+
+filled.contour(x = bh.b.seq,y = bh.a.seq,z = log10(change.a.b.mat),ylab = 'BH-beta',xlab = 'BH-alpha')

--- a/currentVersion/at_biology.prm
+++ b/currentVersion/at_biology.prm
@@ -341,13 +341,13 @@ flagseperateNSH  1         CEP, CEPj are: 1 = seperate groups (or single pool), 
 flagseperateOSH  1         CEP, CEPj are: 1 = seperate groups (or single pool), 0 = age structured single group
 
 # RM 20190103 changed all from 10 to 3
-flagrecruitMAK 3
-flagrecruitHER 3
-flagrecruitWHK 3
-flagrecruitBLF 3
+flagrecruitMAK 11
+flagrecruitHER 11
+flagrecruitWHK 11
+flagrecruitBLF 11
 flagrecruitWPF 1
-flagrecruitSUF 3
-flagrecruitWIF 3
+flagrecruitSUF 11
+flagrecruitWIF 11
 flagrecruitWTF 1
 flagrecruitHAL 1
 flagrecruitPLA 1
@@ -356,14 +356,14 @@ flagrecruitFLA 1
 flagrecruitBFT 1
 flagrecruitTUN 1
 flagrecruitBIL 1
-flagrecruitMPF 3
+flagrecruitMPF 11
 flagrecruitBUT 3
 flagrecruitANC 1
 flagrecruitBPF 1
-flagrecruitGOO 3
+flagrecruitGOO 11
 flagrecruitMEN 1
 flagrecruitFDE 1
-flagrecruitCOD 3
+flagrecruitCOD 11
 flagrecruitSHK 3
 flagrecruitOHK 1
 flagrecruitPOL 3
@@ -371,17 +371,17 @@ flagrecruitRHK 3
 flagrecruitBSB 3
 flagrecruitSCU 3
 flagrecruitTYL 1
-flagrecruitRED 3
+flagrecruitRED 11
 flagrecruitOPT 1
 flagrecruitSAL 1
 flagrecruitDRM 3
-flagrecruitSTB 3
+flagrecruitSTB 11
 flagrecruitTAU 1
 flagrecruitWOL 1
 flagrecruitSDF 1
 flagrecruitFDF 1
 flagrecruitHAD 3
-flagrecruitYTF 3
+flagrecruitYTF 11
 flagrecruitDOG 1
 flagrecruitSMO 1
 flagrecruitSSH 1
@@ -15195,13 +15195,13 @@ KSPA_YTF	27.42
 
 ## proportion of weight used for spawn production
 ####FSP_FPL          0.246     Fraction used in spawning formulation for large planktivores       0.246
-FSP_MAK 0.25
+FSP_MAK 0.125
 FSP_HER 0.15
 FSP_WHK 0.25
 FSP_BLF 0.25
 FSP_WPF 0.25  
-FSP_SUF 0.25
-FSP_WIF 0.25
+FSP_SUF 0.0064
+FSP_WIF 0.00075
 FSP_WTF 0.25  
 FSP_HAL 0.25  
 FSP_PLA 0.25  
@@ -15217,7 +15217,7 @@ FSP_BPF 0.246
 FSP_GOO 0.25
 FSP_MEN 0.276  
 FSP_FDE 0.25
-FSP_COD 0.25
+FSP_COD 0.005
 FSP_SHK 0.25
 FSP_OHK 0.276  
 FSP_POL 0.25
@@ -15229,13 +15229,13 @@ FSP_RED 0.25
 FSP_OPT 0.276  
 FSP_SAL 0.276  
 FSP_DRM 0.25
-FSP_STB 0.25
+FSP_STB 0.009
 FSP_TAU 0.276  
 FSP_WOL 0.276  
 FSP_SDF 0.276  
 FSP_FDF 0.276  
 FSP_HAD 0.25
-FSP_YTF 0.25
+FSP_YTF 0.005
 FSP_DOG 0.3   
 FSP_SMO 0.27   
 FSP_SSH 0.27   

--- a/currentVersion/at_biology.prm
+++ b/currentVersion/at_biology.prm
@@ -341,13 +341,13 @@ flagseperateNSH  1         CEP, CEPj are: 1 = seperate groups (or single pool), 
 flagseperateOSH  1         CEP, CEPj are: 1 = seperate groups (or single pool), 0 = age structured single group
 
 # RM 20190103 changed all from 10 to 3
-flagrecruitMAK 11
-flagrecruitHER 11
-flagrecruitWHK 11
-flagrecruitBLF 11
+flagrecruitMAK 3
+flagrecruitHER 3
+flagrecruitWHK 3
+flagrecruitBLF 3
 flagrecruitWPF 1
-flagrecruitSUF 11
-flagrecruitWIF 11
+flagrecruitSUF 3
+flagrecruitWIF 3
 flagrecruitWTF 1
 flagrecruitHAL 1
 flagrecruitPLA 1
@@ -356,32 +356,32 @@ flagrecruitFLA 1
 flagrecruitBFT 1
 flagrecruitTUN 1
 flagrecruitBIL 1
-flagrecruitMPF 11
-flagrecruitBUT 11
+flagrecruitMPF 3
+flagrecruitBUT 3
 flagrecruitANC 1
 flagrecruitBPF 1
-flagrecruitGOO 11
+flagrecruitGOO 3
 flagrecruitMEN 1
 flagrecruitFDE 1
-flagrecruitCOD 11
-flagrecruitSHK 11
+flagrecruitCOD 3
+flagrecruitSHK 3
 flagrecruitOHK 1
-flagrecruitPOL 11
-flagrecruitRHK 11
-flagrecruitBSB 11
-flagrecruitSCU 11
+flagrecruitPOL 3
+flagrecruitRHK 3
+flagrecruitBSB 3
+flagrecruitSCU 3
 flagrecruitTYL 1
-flagrecruitRED 11
+flagrecruitRED 3
 flagrecruitOPT 1
 flagrecruitSAL 1
-flagrecruitDRM 11
-flagrecruitSTB 11
+flagrecruitDRM 3
+flagrecruitSTB 3
 flagrecruitTAU 1
 flagrecruitWOL 1
 flagrecruitSDF 1
 flagrecruitFDF 1
-flagrecruitHAD 11
-flagrecruitYTF 11
+flagrecruitHAD 3
+flagrecruitYTF 3
 flagrecruitDOG 1
 flagrecruitSMO 1
 flagrecruitSSH 1
@@ -11738,8 +11738,8 @@ C_SDF	10
 C_FDF	10								
 0.24	1.48	3.7	6.8	10	13.7	16.6	19.6	22	24.2
 									
-C_HAD	10								
-0.9125	18.825	54.6375	94.15	104.95	110.05	112.4	141.875	170.925	228.4
+C_HAD	10							
+0.91	18.8	54.6	94	105	110	112.4	141.9	171	228.4
 									
 C_YTF	10								
 0.065	0.31	0.6	1	1.25	1.5	1.75	1.9	2	2.075	
@@ -11955,8 +11955,8 @@ mum_SDF	10.00
 mum_FDF	10.00								
 2.4	14.8	37	68	100	137	166	196	220	242
 									
-mum_HAD	10.00								
-9.125	188.25	546.375	941.5	1049.5	1100.5	1124	1418.75	1709.25	2284
+mum_HAD	10.00						
+9	188	546	941	1049	1100	1124	1418	1709	2284
 									
 mum_YTF	10.00		
 1.3	6.2	12.5	20	25.5	30.5	39.5	38	40	41.5
@@ -15195,13 +15195,13 @@ KSPA_YTF	27.42
 
 ## proportion of weight used for spawn production
 ####FSP_FPL          0.246     Fraction used in spawning formulation for large planktivores       0.246
-FSP_MAK 0.125
+FSP_MAK 0.25
 FSP_HER 0.15
-FSP_WHK 0.025
-FSP_BLF 0.00625
+FSP_WHK 0.25
+FSP_BLF 0.25
 FSP_WPF 0.25  
-FSP_SUF 0.0064
-FSP_WIF 0.00075
+FSP_SUF 0.25
+FSP_WIF 0.25
 FSP_WTF 0.25  
 FSP_HAL 0.25  
 FSP_PLA 0.25  
@@ -15210,32 +15210,32 @@ FSP_FLA 0.25
 FSP_BFT 0.25  
 FSP_TUN 0.25  
 FSP_BIL 0.25  
-FSP_MPF 0.09
-FSP_BUT 0.0625
+FSP_MPF 0.25
+FSP_BUT 0.25
 FSP_ANC 0.246  
 FSP_BPF 0.246  
-FSP_GOO 0.03
+FSP_GOO 0.25
 FSP_MEN 0.276  
-FSP_FDE 0.135
-FSP_COD 0.005
-FSP_SHK 0.005
+FSP_FDE 0.25
+FSP_COD 0.25
+FSP_SHK 0.25
 FSP_OHK 0.276  
-FSP_POL 0.0015
-FSP_RHK 0.0003
-FSP_BSB 0.00975
-FSP_SCU 0.001 
+FSP_POL 0.25
+FSP_RHK 0.25
+FSP_BSB 0.25
+FSP_SCU 0.25
 FSP_TYL 0.276  
-FSP_RED 0.015
+FSP_RED 0.25
 FSP_OPT 0.276  
 FSP_SAL 0.276  
-FSP_DRM 0.0005 
-FSP_STB 0.009
+FSP_DRM 0.25
+FSP_STB 0.25
 FSP_TAU 0.276  
 FSP_WOL 0.276  
 FSP_SDF 0.276  
 FSP_FDF 0.276  
-FSP_HAD 0.0005 
-FSP_YTF 0.005
+FSP_HAD 0.25
+FSP_YTF 0.25
 FSP_DOG 0.3   
 FSP_SMO 0.27   
 FSP_SSH 0.27   
@@ -15388,7 +15388,7 @@ FSPB_FDF 10
 0.2 0.9 1 1 1 1 1 1 1 1
  
 FSPB_HAD 10
-0.2 0.95 1 1 1 1 1 1 1 1
+0 0.95 1 1 1 1 1 1 1 1
  
 FSPB_YTF 10
 0 0.8 1 1 1 1 1 1 1 1


### PR DESCRIPTION
## Turned on Beverton-Holt Recruitment for some groups 
- Only groups that persisted with B-H turned on are kep. FSP set to 0.25 for those
- Groups that weren't flagrecruit = 11 were kept as is
- Groups that didn't persist with B-H v1 parameters were reverted back (recruit type and FSP)

## New Functions
edit_param_BH.R : Function to edit beverton-holt parameters in biology.prm
model_BH.R : Testing ground for manipulating recruitment parameters and results.
